### PR TITLE
Used ansible_facts for logic 

### DIFF
--- a/get_serials.yml
+++ b/get_serials.yml
@@ -12,10 +12,6 @@
         - hardware
     register: facts_results
 
-#  - name: Display contentes of ios_facts variable
-#    debug:
-#      var: facts_results
-
   - name: Create Output Directory
     file:
      path: "{{ dest_dir }}"
@@ -26,3 +22,7 @@
     template:
       src: "templates/inventory.j2"
       dest: "{{ dest_dir }}/{{ ansible_facts.net_hostname }}-inventory.txt"
+
+#  - name: Display contentes of ios_facts variable
+#    debug:
+#      var: facts_results

--- a/group_vars/access-switches/vars.yml
+++ b/group_vars/access-switches/vars.yml
@@ -1,3 +1,2 @@
 ---
 ansible_become_pass: "{{ vault_access_secret }}"
-device_type: access_switch

--- a/group_vars/distro-switches/vars.yml
+++ b/group_vars/distro-switches/vars.yml
@@ -1,3 +1,2 @@
 ---
 ansible_become_pass: "{{ vault_distro_secret }}"
-device_type: distro_switch

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -1,7 +1,8 @@
-{{ansible_facts.net_hostname}} MODEL: {{ansible_facts.net_model}}
+Hostname: {{ansible_net_hostname}}
+MODEL: {{ansible_net_model}}
 
-SERIAL NUMBERS:
-{% if device_type == "access_switch" %}
+SERIAL NUMBER(S):
+{% if ansible_net_stacked_serialnums is defined %}
 {% for serial in ansible_net_stacked_serialnums %}
 {{serial}}
 {% endfor %}


### PR DESCRIPTION
Decided to use variables gathered from ansible_facts/ios_facts instead of hard-coding variables to determine if a devices was a switch stack or single router/switch